### PR TITLE
MappingNetwork - adjusted output dim to model resolution

### DIFF
--- a/stylegan2_generator.py
+++ b/stylegan2_generator.py
@@ -12,12 +12,12 @@ class MappingNetwork(tf.keras.layers.Layer):
     """
     StyleGan2 generator mapping network, from z to dlatents for tensorflow 2.x
     """
-    def __init__(self, **kwargs):
+    def __init__(self, resolution=1024, impl='cuda', gpu=True, **kwargs):
         
         super(MappingNetwork, self).__init__(**kwargs)
         
         self.dlatent_size = 512
-        self.dlatent_vector = 18
+        self.dlatent_vector = (int(np.log2(resolution))-1)*2
         self.mapping_layers = 8
         self.lrmul = 0.01
         
@@ -140,7 +140,8 @@ class StyleGan2Generator(tf.keras.layers.Layer):
         self.resolution = resolution
         if weights is not None: self.__adjust_resolution(weights)
 
-        self.mapping_network = MappingNetwork(name='Mapping_network')
+        self.mapping_network = MappingNetwork(resolution=self.resolution, impl=impl, 
+                                                  gpu=gpu,name='Mapping_network')
         self.synthesis_network = SynthesisNetwork(resolution=self.resolution, impl=impl, 
                                                   gpu=gpu, name='Synthesis_network')
         


### PR DESCRIPTION
Hi Alberto,
I have adjusted the dimension of the MappingNetwork output vector to the model dimension as discussed. Kept changes minimal and tested successfully with your and mine examples.
Best
Hans